### PR TITLE
Fix btoa to match browser implementations

### DIFF
--- a/btoa/index.js
+++ b/btoa/index.js
@@ -2,7 +2,7 @@
   "use strict";
 
   function btoa(str) {
-    return new Buffer(str, 'utf8').toString('base64');
+    return new Buffer(str, 'binary').toString('base64');
   }
 
   module.exports = btoa;


### PR DESCRIPTION
`btoa` does not match the browser-side implementations.

For example, in Chrome,  `btoa(String.fromCharCode(252))` returns `"/A=="`. This commit fixes `btoa`.
