### PR TITLE
Fix atob to match browser implementations

### DIFF
--- a/atob/index.js
+++ b/atob/index.js
@@ -2,7 +2,7 @@
   "use strict";
 
   function atob(str) {
-    return new Buffer(str, 'base64').toString('utf8');
+    return new Buffer(str, 'base64').toString('binary');
   }
 
   module.exports = atob;


### PR DESCRIPTION
`atob` does not match browser-side implementations

For example, `atob('/A==') === String.fromCharCode(252)` is true in Chrome. This commit makes `atob` behave like the browser version (for better or for worse).
